### PR TITLE
Fix: make sure `e` or `w` are at the start of the line

### DIFF
--- a/lua/cmp_fuzzy_path/init.lua
+++ b/lua/cmp_fuzzy_path/init.lua
@@ -36,7 +36,7 @@ end
 
 local PATH_REGEX = ([[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]])
 local COMPILED_PATH_REGEX = vim.regex(PATH_REGEX)
-local COMMAND_SHORTCUT = vim.regex([[\%^\(e\|w\)\s\+]])
+local COMMAND_SHORTCUT = vim.regex([[^\%(e\|w\)\s\+]])
 
 source.get_keyword_pattern = function(_, params)
   if vim.api.nvim_get_mode().mode == 'c' then

--- a/lua/cmp_fuzzy_path/init.lua
+++ b/lua/cmp_fuzzy_path/init.lua
@@ -36,7 +36,7 @@ end
 
 local PATH_REGEX = ([[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]])
 local COMPILED_PATH_REGEX = vim.regex(PATH_REGEX)
-local COMMAND_SHORTCUT = vim.regex([[\%(e\|w\)\s\+]])
+local COMMAND_SHORTCUT = vim.regex([[\%^\(e\|w\)\s\+]])
 
 source.get_keyword_pattern = function(_, params)
   if vim.api.nvim_get_mode().mode == 'c' then


### PR DESCRIPTION
This prevents commands which do not start with `e` or `w` from triggering the source
Example cases: `:execute` and `:Telescope`