### PR TITLE
feat: provide options to override triggering regex and path regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ entire path, not just on the file or directory name.
 Please note that, by default, `fd` returns only files. If you want directories,
 you need to add `-t d -t f` to `fd_cmd` table.
 
+## cmd_trigger_regex (type: string)
+
+_Default:_ `[[^\%(e\|w\)\s\+]]`
+
+The regular expression to use to trigger the plugin when in command mode.
+
+## path_regex (type: string)
+
+_Default:_ `[[^\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]`
+
+The regular expression to use to match paths.
+
 # Sorting
 
 `cmp-fuzzy-path` adds a score entry to each completion item's `data` field,


### PR DESCRIPTION
This commit should allow users to override the default cmdline triggering regex and path regex.

The current cmdline triggering regex is not perfect in some cases (e.g. it does not trigger when user types `:edit ...` or `:vsplit | e ...` instead of `:e ...`, to avoid complexity, I think it is better to let users to promote the default regex if needed