### PR TITLE
feat: use getcmdcompltype() instead of regex to decide whether to pro…

### DIFF
--- a/lua/cmp_fuzzy_path/init.lua
+++ b/lua/cmp_fuzzy_path/init.lua
@@ -41,7 +41,6 @@ end
 
 local PATH_REGEX = [[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]
 local COMPILED_PATH_REGEX = vim.regex(PATH_REGEX)
-local COMMAND_SHORTCUT = vim.regex([[^\%(e\|w\)\s\+]])
 
 source.get_keyword_pattern = function(_, params)
   if vim.api.nvim_get_mode().mode == 'c' then
@@ -92,7 +91,8 @@ source.complete = function(self, params, callback)
       callback({ items = {}, isIncomplete = true })
       return
     end
-    if COMMAND_SHORTCUT:match_str(params.context.cursor_before_line) then
+    local compltype = vim.fn.getcmdcompltype()
+    if compltype == 'file' or compltype == 'dir' then
       pattern = params.context.cursor_before_line:sub(params.offset)
     else
       pattern = find_pattern(params.context.cursor_before_line)


### PR DESCRIPTION
…vide completion

@tzachar I decide that this is a better solution to the previous pull request, it takes advantage of `getcmdcompltype()` instead of relying on regex to decide whether cmp-fuzzy-path should provide completions. Unlike current implementation, where fuzzy-path completions are only provided when the preceding cmdline contents matches a certain regex, it works in all cases in cmdline mode when completions for files or directories should be provided.

Looking forward to your advice.