### PR TITLE
feat: optional args `path_regex` for completions (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ first character of the command is in `{'e', 'w'}`.
 # Installation
 
 Using [Packer](https://github.com/wbthomason/packer.nvim/) with `fzf`:
+
 ```lua
 use {'nvim-telescope/telescope-fzf-native.nvim', run = 'make'}
 use "hrsh7th/nvim-cmp"
@@ -30,6 +31,7 @@ use {'tzachar/cmp-fuzzy-path', requires = {'hrsh7th/nvim-cmp', 'tzachar/fuzzy.nv
 ```
 
 Using [Packer](https://github.com/wbthomason/packer.nvim/) with `fzy`:
+
 ```lua
 use {'romgrk/fzy-lua-native', run = 'make'}
 use "hrsh7th/nvim-cmp"
@@ -38,7 +40,6 @@ use {'tzachar/cmp-fuzzy-path', requires = {'hrsh7th/nvim-cmp', 'tzachar/fuzzy.nv
 
 You should have `fd` in your `PATH`, or edit the configuation to point at the
 exact location.
-
 
 # Setup
 
@@ -51,6 +52,7 @@ require'cmp'.setup {
 ```
 
 This plugin can also be used to complete file names for `:edit` or `:write` in cmdline mode of cmp:
+
 ```lua
 cmp.setup.cmdline(':', {
   sources = cmp.config.sources({
@@ -60,7 +62,6 @@ cmp.setup.cmdline(':', {
 ```
 
 *Note:* the plugin's name is `fuzzy_path` in `cmp`'s config.
-
 
 # Configuration
 
@@ -76,14 +77,14 @@ cmp.setup.cmdline(':', {
 
 ## fd_timeout_msec (type: int)
 
-_Default:_ 500
+*Default:* 500
 
 How much grace to give the file finder before killing it. If you set this to too
 short a value, you will probably not get enough suggestions.
 
 ## fd_cmd (type: table(string))
 
-_Default:_ `{'fd', '-d', '20', '-p'}`
+*Default:* `{'fd', '-d', '20', '-p'}`
 
 The commend to use as a file finder. Note that `-p` is needed so we match on the
 entire path, not just on the file or directory name.
@@ -91,11 +92,18 @@ entire path, not just on the file or directory name.
 Please note that, by default, `fd` returns only files. If you want directories,
 you need to add `-t d -t f` to `fd_cmd` table.
 
+## path_regex (type: string)
+
+*Default:* `[[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]`
+
+The path regular expression to complete.
+
+The default `path_regex` ensures the completions triggered only a certain query string entered as we noticed before. If you want to trigger immediately, you may set it like `[[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S*]]`.
+
 # Sorting
 
 `cmp-fuzzy-path` adds a score entry to each completion item's `data` field,
 which can be used to override `cmp`'s default sorting order:
-
 
 ```lua
 local compare = require('cmp.config.compare')
@@ -124,7 +132,7 @@ cmp.setup({
 ## `CmpFuzzyStats`
 
 `CmpFuzzyStats` can be used to gather statistics about the operation of the
-plugin. Output contains the following: 
+plugin. Output contains the following:
 
 - Total Usage Count: how many times the plugin was called
 - Timeout Count: how many times we reached a timeout

--- a/lua/cmp_fuzzy_path/init.lua
+++ b/lua/cmp_fuzzy_path/init.lua
@@ -15,6 +15,10 @@ local defaults = {
   path_regex = [[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]
 }
 
+local compiled_path_regexes = {
+  [defaults.path_regex] = vim.regex(defaults.path_regex),
+}
+
 source.new = function()
   return setmetatable({}, { __index = source })
 end
@@ -40,14 +44,20 @@ source.get_trigger_characters = function()
   return { '.', '/', '~' }
 end
 
-local COMPILED_PATH_REGEX = vim.regex(defaults.path_regex)
+local function get_compiled_path_regex(path_regex)
+  local pattern = path_regex or defaults.path_regex
+  if compiled_path_regexes[pattern] == nil then
+    compiled_path_regexes[pattern] = vim.regex(pattern)
+  end
+  return compiled_path_regexes[pattern]
+end
 
 source.get_keyword_pattern = function(_, params)
-  COMPILED_PATH_REGEX = vim.regex(params.option.path_regex)
+  local option = vim.tbl_deep_extend('keep', params.option or {}, defaults)
   if vim.api.nvim_get_mode().mode == 'c' then
     return [[\S\+]]
   else
-    return params.option.path_regex
+    return option.path_regex
   end
 end
 
@@ -73,8 +83,8 @@ source.stat = function(_, path)
   return nil
 end
 
-local function find_pattern(cursor_before_line)
-  local match_start, match_end = COMPILED_PATH_REGEX:match_str(cursor_before_line)
+local function find_pattern(cursor_before_line, compiled_path_regex)
+  local match_start, match_end = compiled_path_regex:match_str(cursor_before_line)
   if not match_start then
     return
   else
@@ -84,6 +94,7 @@ end
 
 source.complete = function(self, params, callback)
   params.option = vim.tbl_deep_extend('keep', params.option, defaults)
+  local compiled_path_regex = get_compiled_path_regex(params.option.path_regex)
   local is_cmd = (vim.api.nvim_get_mode().mode == 'c')
   local pattern = nil
   if is_cmd then
@@ -96,10 +107,10 @@ source.complete = function(self, params, callback)
     if compltype == 'file' or compltype == 'dir' then
       pattern = params.context.cursor_before_line:sub(params.offset)
     else
-      pattern = find_pattern(params.context.cursor_before_line)
+      pattern = find_pattern(params.context.cursor_before_line, compiled_path_regex)
     end
   else
-    pattern = find_pattern(params.context.cursor_before_line)
+    pattern = find_pattern(params.context.cursor_before_line, compiled_path_regex)
   end
   if not pattern then
     callback({ items = {}, isIncomplete = true })

--- a/lua/cmp_fuzzy_path/init.lua
+++ b/lua/cmp_fuzzy_path/init.lua
@@ -12,6 +12,7 @@ local source = {
 local defaults = {
   fd_cmd = { 'fd', '-d', '20', '-p', '-i' },
   fd_timeout_msec = 500,
+  path_regex = [[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]
 }
 
 source.new = function()
@@ -39,14 +40,14 @@ source.get_trigger_characters = function()
   return { '.', '/', '~' }
 end
 
-local PATH_REGEX = [[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]
-local COMPILED_PATH_REGEX = vim.regex(PATH_REGEX)
+local COMPILED_PATH_REGEX = vim.regex(defaults.path_regex)
 
 source.get_keyword_pattern = function(_, params)
+  COMPILED_PATH_REGEX = vim.regex(params.option.path_regex)
   if vim.api.nvim_get_mode().mode == 'c' then
     return [[\S\+]]
   else
-    return PATH_REGEX
+    return params.option.path_regex
   end
 end
 
@@ -146,11 +147,14 @@ source.complete = function(self, params, callback)
   local filterText = string.sub(params.context.cursor_before_line, params.offset)
 
   -- indicate that we are searching for files
-  callback({ items = { {
-    label = 'Searching...',
-    filterText = filterText,
-    data = { path = nil, stat = nil, score = -1000 },
-  } }, isIncomplete = true })
+  callback({
+    items = { {
+      label = 'Searching...',
+      filterText = filterText,
+      data = { path = nil, stat = nil, score = -1000 },
+    } },
+    isIncomplete = true
+  })
   local job
   local job_start = vim.fn.reltime()
   job = fn.jobstart(cmd, {
@@ -161,11 +165,14 @@ source.complete = function(self, params, callback)
         return
       end
       if #items == 0 then
-        callback({ items = { {
-          label = 'No matches found',
-          filterText = filterText,
-          data = { path = nil, stat = nil, score = -1000 },
-        } }, isIncomplete = true })
+        callback({
+          items = { {
+            label = 'No matches found',
+            filterText = filterText,
+            data = { path = nil, stat = nil, score = -1000 },
+          } },
+          isIncomplete = true
+        })
       else
         callback({ items = items, isIncomplete = true })
       end


### PR DESCRIPTION
This PR add a newly option field named `path_regex` for completions query, which default to `[[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S\+]]` and make the plugin works as usual.

The following example show how to make completion triggered immediately when leading `/` or `./` entered

```lua
option = {
      path_regex = [[\%(\k\?[/:\~]\+\|\.\?\.\/\)\S*]]
}
```

close #13 